### PR TITLE
Fix checking support for 'post_parent__in'

### DIFF
--- a/includes/common/functions.php
+++ b/includes/common/functions.php
@@ -1462,7 +1462,7 @@ function bbp_query_post_parent__in( $where, $object = '' ) {
 	global $wp;
 
 	// Noop if WP core supports this already
-	if ( in_array( 'post_parent__in', $wp->private_query_vars ) ) {
+	if ( empty($wp) || in_array( 'post_parent__in', $wp->private_query_vars ) ) {
 		return $where;
 	}
 


### PR DESCRIPTION
Prevent throwing a Warning when `$wp` is null. This happens everytime a WP Query is made before WP is instanciated.